### PR TITLE
Copy xcschememanagement.plist

### DIFF
--- a/xcodeproj/internal/templates/installer.sh
+++ b/xcodeproj/internal/templates/installer.sh
@@ -150,7 +150,7 @@ rsync \
   --chmod=u+w,F-x \
   --exclude=project.xcworkspace \
   --exclude=rules_xcodeproj/bazel \
-  --exclude=xcuserdata \
+  --exclude="*.xcbkptlist" \
   --delete \
   "$src/" "$dest/"
 


### PR DESCRIPTION
`xcschememanagement.plist` is not copied due to a recent change https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/2700. 

I am making the change so that the breakpoint file is preserved, but `xcschememanagement.plist` containing scheme order hint is copied as expected